### PR TITLE
Devel: adds car start problem to tests

### DIFF
--- a/bayesian/tests/networks.py
+++ b/bayesian/tests/networks.py
@@ -1,5 +1,51 @@
 import bayesian
 
+class CarStartProblem(bayesian.Network):
+    def __init__(self):
+        """Bayesian network implementing the car start problem
+    
+        This test is taken from page 35 of:
+
+        Jensen, Finn V. and Nielsen, Thomas D., Bayesian Network and Decision 
+        Graph, Springer New York, 2007.
+
+        """
+
+        bayesian.Network.__init__(self)
+
+        # fuel  : Does the car have fuel?
+        # meter : What does the fuel meter say?
+        # start : Does the car start?
+        # spark : Are the spark plugs clean?
+        fuel = bayesian.Variable('Fu')
+        meter = bayesian.Variable('Fm', 3)
+        start = bayesian.Variable('St')
+        spark = bayesian.Variable('Sp')
+
+        # It is very likely the car has fuel.
+        fuel_table = bayesian.Table([fuel], [0.02, 0.98])
+
+        # It is very likely the spark plug is clean.
+        spark_table = bayesian.Table([spark], [0.04, 0.96])
+
+        # The meter depends on the fuel.
+        meter_table = bayesian.Table([fuel, meter], [
+            [0.998, 0.001, 0.001], 
+            [0.01, 0.60, 0.39]
+        ])
+
+        # The car will start if there is fuel and the spark plug is 
+        # clean.
+        start_table = bayesian.Table([start, fuel, spark], [
+            [[1.0, 1.0], [0.99, 0.01]],
+            [[0.0, 0.0], [0.01, 0.99]]
+        ])
+
+        self.add_table(fuel_table)
+        self.add_table(spark_table)
+        self.add_table(meter_table)
+        self.add_table(start_table)
+
 class Pyramid(bayesian.Network):
     def __init__(self):
         """Pyramid Bayesian network used for tests

--- a/bayesian/tests/test_junction_junctiontree.py
+++ b/bayesian/tests/test_junction_junctiontree.py
@@ -7,10 +7,21 @@ import bayesian.tests.networks
 class TestGraphJunctionTree(unittest.TestCase):
     """Test the JunctionTree class"""
 
-    def test_marginals(self):
+    def test_marignals(self):
         """Test the marginals method"""
+        
+        # Get the available test networks.
+        networks = [
+            bayesian.tests.networks.Pyramid(),
+            bayesian.tests.networks.CarStartProblem()
+        ]
 
-        network = bayesian.tests.networks.Pyramid()
+        # Test them one by one.
+        for network in networks:
+            self._test_marginals_network(network)
+
+    def _test_marginals_network(self, network):
+        """Test the marginals method using a test network"""
 
         # Compute the marginals using the junction tree.
         junction_tree = bayesian.JunctionTree(network)

--- a/bayesian/tests/test_problems.py
+++ b/bayesian/tests/test_problems.py
@@ -1,63 +1,42 @@
 import unittest
 import bayesian
+import bayesian.tests.networks
 
 class TestUsingProblems(unittest.TestCase):
     
     def test_car_start_problem(self):
-        """Test the bayesian module using the car start problem
+        """Test the bayesian module using the car start problem"""
 
-        This test is taken from page 35 of:
+        # Generate the network for the car start problem. 
+        network = bayesian.tests.networks.CarStartProblem()
 
-        Jensen, Finn V. and Nielsen, Thomas D., Bayesian Network and Decision 
-        Graph, Springer New York, 2007.
+        # Get the start and fuel meter variables.
+        variables = network.domain
+        symbols = [variable.symbol for variable in variables]
+        start = variables[symbols.index('St')]
+        fuel = variables[symbols.index('Fu')]
+        spark = variables[symbols.index('Sp')]
+        meter = variables[symbols.index('Fm')]
 
-        """
-
-        # Fu : Does the car have fuel?
-        # FM : What does the fuel meter say?
-        # St : Does the car start?
-        # Sp : Are the spark plugs clean?
-        Fu = bayesian.Variable('Fu')
-        Fm = bayesian.Variable('Fm', 3)
-        St = bayesian.Variable('St')
-        Sp = bayesian.Variable('Sp')
-
-        PFu = bayesian.Table([Fu], [0.02, 0.98])
-        PSp = bayesian.Table([Sp], [0.04, 0.96])
-        PFm = bayesian.Table([Fu, Fm], [
-            [0.998, 0.001, 0.001], 
-            [0.01, 0.60, 0.39]
-        ])
-        PSt = bayesian.Table([St, Fu, Sp], [
-            [[1.0, 1.0], [0.99, 0.01]],
-            [[0.0, 0.0], [0.01, 0.99]]
-        ])
-
-        bn = bayesian.Network()
-        bn.add_table(PFu)
-        bn.add_table(PSp)
-        bn.add_table(PFm)
-        bn.add_table(PSt)
-       
         # Add evidence for the St variable.
-        ESt = bayesian.Table([St], [1.0, 0.0])
-        bn.add_table(ESt)
+        evidence_start = bayesian.Table([start], [1.0, 0.0])
+        network.add_table(evidence_start)
 
         # Verify the result agree with the reference.
-        self.assertAlmostEqual(bn.marginal(Fu)[0], 0.29, 2)
-        self.assertAlmostEqual(bn.marginal(Fu)[1], 0.71, 2)
-        self.assertAlmostEqual(bn.marginal(Sp)[0], 0.58, 2)
-        self.assertAlmostEqual(bn.marginal(Sp)[1], 0.42, 2)
+        self.assertAlmostEqual(network.marginal(fuel)[0], 0.29, 2)
+        self.assertAlmostEqual(network.marginal(fuel)[1], 0.71, 2)
+        self.assertAlmostEqual(network.marginal(spark)[0], 0.58, 2)
+        self.assertAlmostEqual(network.marginal(spark)[1], 0.42, 2)
 
         # Add evidence for the Fm variable.
-        EFm = bayesian.Table([Fm], [0.0, 1.0, 0.0]) 
-        bn.add_table(EFm)
+        evidence_meter = bayesian.Table([meter], [0.0, 1.0, 0.0]) 
+        network.add_table(evidence_meter)
 
         # Verify the result agree with the reference.
-        self.assertAlmostEqual(bn.marginal(Sp)[0], 0.804, 2)
-        self.assertAlmostEqual(bn.marginal(Sp)[1], 0.196, 2)
-        self.assertAlmostEqual(bn.marginal(Fu)[0], 0.001, 2)
-        self.assertAlmostEqual(bn.marginal(Fu)[1], 0.999, 2)
+        self.assertAlmostEqual(network.marginal(spark)[0], 0.804, 2)
+        self.assertAlmostEqual(network.marginal(spark)[1], 0.196, 2)
+        self.assertAlmostEqual(network.marginal(fuel)[0], 0.001, 2)
+        self.assertAlmostEqual(network.marginal(fuel)[1], 0.999, 2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This merge improves the quality of tests by adding a standard car start network instead of defining the network directly in test methods.